### PR TITLE
Add scripts for installing kOps

### DIFF
--- a/images/linux/scripts/installers/kubernetes-tools.sh
+++ b/images/linux/scripts/installers/kubernetes-tools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 ################################################################################
 ##  File:  kubernetes-tools.sh
-##  Desc:  Installs kubectl, helm, kustomize
+##  Desc:  Installs kubectl, helm, kustomize, kops
 ################################################################################
 
 # Source the helpers for use with the script
@@ -28,5 +28,16 @@ sudo install minikube-linux-amd64 /usr/local/bin/minikube
 download_url="https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 curl -s "$download_url" | bash
 mv kustomize /usr/local/bin
+
+# Install kops
+download_url="https://github.com/kubernetes/kops/releases/download"
+KOPS_VERSION=$(curl -s "https://api.github.com/repos/kubernetes/kops/releases/latest" | grep tag_name | cut -d '"' -f 4)
+package="kops-linux-amd64"
+dest_directory="/usr/local/bin/kops"
+
+curl -LO "$download_url/$KOPS_VERSION/$package"
+chmod +x $package
+sudo mv $package $dest_directory
+
 
 invoke_tests "Tools" "Kubernetes tools"

--- a/images/linux/scripts/tests/Tools.Tests.ps1
+++ b/images/linux/scripts/tests/Tools.Tests.ps1
@@ -302,6 +302,10 @@ Describe "Kubernetes tools" {
     It "kustomize" {
         "kustomize version" | Should -ReturnZeroExitCode
     }
+
+    It "kops" {
+        "kops version" | Should -ReturnZeroExitCode
+    }
 }
 
 Describe "Leiningen" {

--- a/images/macos/provision/core/kubernetes-tools.sh
+++ b/images/macos/provision/core/kubernetes-tools.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e -o pipefail
+
+################################################################################
+##  File:  kubernetes-tools.sh
+##  Desc:  Installs kubectl, kops
+################################################################################
+
+# Check if Homebrew is installed and update it if so
+if [[ $(command -v brew) == "" ]]; then
+    echo "No Homebrew found. Installing necessary tools..." && echo ""
+    homebrew_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    source ${homebrew_script_dir}/homebrew.sh
+else
+    echo "Updating Homebrew"
+    brew update
+fi
+
+# Install Kind
+brew install kind
+
+# Install kubectl (prerequisite)
+brew install kubectl
+
+# Install Helm
+brew install helm
+
+# Install minikube
+brew install minikube
+
+# Install kustomize
+brew install kustomize
+
+# Install kops
+brew install kops
+
+invoke_tests "Kubernetes" "Kubernetes tools"

--- a/images/macos/tests/Kubernetes.Tests.ps1
+++ b/images/macos/tests/Kubernetes.Tests.ps1
@@ -1,0 +1,25 @@
+Describe "Kubernetes tools" {
+    It "kind" {
+        "kind --version" | Should -ReturnZeroExitCode
+    }
+
+    It "kubectl" {
+        "kubectl version" | Should -MatchCommandOutput "Client Version: version.Info"
+    }
+
+    It "helm" {
+        "helm version" | Should -ReturnZeroExitCode
+    }
+
+    It "minikube" {
+        "minikube version" | Should -ReturnZeroExitCode
+    }
+
+    It "kustomize" {
+        "kustomize version" | Should -ReturnZeroExitCode
+    }
+
+    It "kops" {
+        "kops version" | Should -ReturnZeroExitCode
+    }
+}

--- a/images/win/scripts/Installers/Install-KubernetesTools.ps1
+++ b/images/win/scripts/Installers/Install-KubernetesTools.ps1
@@ -21,4 +21,7 @@ Choco-Install -PackageName kubernetes-helm
 Write-Host "Install Minikube"
 Choco-Install -PackageName minikube
 
+Write-Host "Install Kubernetes Operations"
+Choco-Install -PackageName kubernetes-kops
+
 Invoke-PesterTests -TestFile "Tools" -TestName "KubernetesTools"

--- a/images/win/scripts/Tests/Tools.Tests.ps1
+++ b/images/win/scripts/Tests/Tools.Tests.ps1
@@ -79,6 +79,10 @@ Describe "KubernetesTools" {
     It "minikube" {
         "minikube version --short" | Should -ReturnZeroExitCode
     }
+
+    It "kops" {
+        "kops version" | Should -ReturnZeroExitCode
+    }
 }
 
 Describe "Mingw64" {


### PR DESCRIPTION
# Description
This pull request seeks to add scripts that would install Kubernetes Operations (kOps) package to the operating system. 

- Scripts are added for all 3 systems - Windows, Linux and MacOS.
- **Installation for Windows** uses Chocolatey (Choco-Install cmdlet defined in the repository) and is located in the same file as the scripts for all other Kubernetes tools;
- **Installation for Linux** uses curl and is located in the same file as all other Kubernetes tools;
- **Installation for MacOS** uses Homebrew package manager for the sake of simplicity (checks if it is available on the OS - if not, triggers the `homebrew.sh` script first; if yes, updates the manager) and is written in a separate file.
- Appropriate unit tests were added inside respective directories for Win and Linux and a new file was created for MacOS.

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
